### PR TITLE
Fix Doom OPL3 detection, clk_host timing improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,25 +92,25 @@ Close up of the attack phase:
     +----------------------------+------+-------+------------+-----------+-------+
     |          Site Type         | Used | Fixed | Prohibited | Available | Util% |
     +----------------------------+------+-------+------------+-----------+-------+
-    | Slice LUTs                 | 1341 |     0 |          0 |     17600 |  7.62 |
-    |   LUT as Logic             | 1107 |     0 |          0 |     17600 |  6.29 |
-    |   LUT as Memory            |  234 |     0 |          0 |      6000 |  3.90 |
-    |     LUT as Distributed RAM |  188 |     0 |            |           |       |
-    |     LUT as Shift Register  |   46 |     0 |            |           |       |
-    | Slice Registers            | 1112 |     0 |          0 |     35200 |  3.16 |
-    |   Register as Flip Flop    | 1112 |     0 |          0 |     35200 |  3.16 |
+    | Slice LUTs                 | 1256 |     0 |          0 |     17600 |  7.14 |
+    |   LUT as Logic             | 1014 |     0 |          0 |     17600 |  5.76 |
+    |   LUT as Memory            |  242 |     0 |          0 |      6000 |  4.03 |
+    |     LUT as Distributed RAM |  192 |     0 |            |           |       |
+    |     LUT as Shift Register  |   50 |     0 |            |           |       |
+    | Slice Registers            | 1106 |     0 |          0 |     35200 |  3.14 |
+    |   Register as Flip Flop    | 1106 |     0 |          0 |     35200 |  3.14 |
     |   Register as Latch        |    0 |     0 |          0 |     35200 |  0.00 |
-    | F7 Muxes                   |    7 |     0 |          0 |      8800 |  0.08 |
+    | F7 Muxes                   |    9 |     0 |          0 |      8800 |  0.10 |
     | F8 Muxes                   |    1 |     0 |          0 |      4400 |  0.02 |
     +----------------------------+------+-------+------------+-----------+-------+
 
     +-------------------+------+-------+------------+-----------+-------+
     |     Site Type     | Used | Fixed | Prohibited | Available | Util% |
     +-------------------+------+-------+------------+-----------+-------+
-    | Block RAM Tile    |    3 |     0 |          0 |        60 |  5.00 |
+    | Block RAM Tile    |  3.5 |     0 |          0 |        60 |  5.83 |
     |   RAMB36/FIFO*    |    0 |     0 |          0 |        60 |  0.00 |
-    |   RAMB18          |    6 |     0 |          0 |       120 |  5.00 |
-    |     RAMB18E1 only |    6 |       |            |           |       |
+    |   RAMB18          |    7 |     0 |          0 |       120 |  5.83 |
+    |     RAMB18E1 only |    7 |       |            |           |       |
     +-------------------+------+-------+------------+-----------+-------+
 
 ## Serial command line interface

--- a/fpga/modules/host_if/src/host_if.sv
+++ b/fpga/modules/host_if/src/host_if.sv
@@ -53,17 +53,30 @@ module host_if
     input wire wr_n,
     input wire [1:0] address,
     input wire [REG_FILE_DATA_WIDTH-1:0] din,
-    output logic [REG_FILE_DATA_WIDTH-1:0] dout,
+    output logic [REG_FILE_DATA_WIDTH-1:0] dout = 0,
     output opl3_reg_wr_t opl3_reg_wr = 0,
     input wire [REG_FILE_DATA_WIDTH-1:0] status,
     output logic force_timer_overflow
 );
+    logic cs_p1_n = 1;
+    logic wr_p1_n = 1;
+    logic [1:0] address_p1 = 0;
+    logic [REG_FILE_DATA_WIDTH-1:0] din_p1 = 0;
     logic opl3_fifo_empty;
     logic [1:0] opl3_address;
     logic [REG_FILE_DATA_WIDTH-1:0] opl3_data;
-    logic wr;
+    logic wr_p1;
+    logic [REG_FILE_DATA_WIDTH-1:0] host_status;
 
-    always_comb wr = !cs_n && !wr_n;
+    // relax timing on clk_host
+    always_ff @(posedge clk_host) begin
+        cs_p1_n <= cs_n;
+        wr_p1_n <= wr_n;
+        address_p1 <= address;
+        din_p1 <= din;
+    end
+
+    always_comb wr_p1 = !cs_p1_n && !wr_p1_n;
 
     afifo #(
         .LGFIFO(6), // use at least 6 to get inferred into BRAM. Increase in ALMs at lower depths
@@ -71,8 +84,8 @@ module host_if
     ) afifo (
 		.i_wclk(clk_host),
 		.i_wr_reset_n(ic_n),
-		.i_wr(wr), // edge detect if write is held for more than 1 cycle
-		.i_wr_data({address, din}),
+		.i_wr(wr_p1),
+		.i_wr_data({address_p1, din_p1}),
 		.o_wr_full(),
 		.i_rclk(clk),
 		.i_rd_reset_n(!reset),
@@ -104,8 +117,13 @@ module host_if
     ) dout_sync (
         .clk(clk_host),
         .in(status),
-        .out(dout)
+        .out(host_status)
     );
+
+    // Doom DMXOPTION=-opl3-phase detection routine specifically reads address 'b10 to see if it's all ones
+    // Decompiled routine provided by Never_Again at https://www.vogons.org/viewtopic.php?f=7&t=100285
+    always_ff @(posedge clk_host)
+        dout <= address_p1 == 0 ? host_status : '1;
 
     generate
     if (INSTANTIATE_TIMERS)

--- a/fpga/modules/host_if/src/trick_sw_detection.sv
+++ b/fpga/modules/host_if/src/trick_sw_detection.sv
@@ -78,51 +78,66 @@ module trick_sw_detection
     input wire [REG_FILE_DATA_WIDTH-1:0] din,
     output logic force_timer_overflow
 );
-    localparam NUM_READS_TO_TRIGGER_OVERFLOW = 20;
+    localparam NUM_READS_TO_TRIGGER_OVERFLOW = 50;
 
-    logic wr;
-    logic wr_p1 = 0;
+    logic cs_p1_n = 1;
+    logic wr_p1_n = 1;
+    logic rd_p1_n = 1;
+    logic [1:0] address_p1 = 0;
+    logic [REG_FILE_DATA_WIDTH-1:0] din_p1 = 0;
+    logic wr_p1;
     logic [$clog2(NUM_READS_TO_TRIGGER_OVERFLOW)-1:0] host_rd_counter = 0;
     opl3_reg_wr_t host_reg_wr;
-    logic rd;
-    logic rd_p1 = 0;
+    logic rd_p1;
+    logic rd_p2 = 0;
     logic host_force_timer_overflow = 0;
     logic start_counter = 0;
+    logic [REG_TIMER_WIDTH-1:0] timer1 = 0;
 
-    always_comb wr = !cs_n && !wr_n;
+    always_ff @(posedge clk_host) begin
+        cs_p1_n <= cs_n;
+        wr_p1_n <= wr_n;
+        rd_p1_n <= rd_n;
+        address_p1 <= address;
+        din_p1 <= din;
+    end
 
-    always_ff @(posedge clk_host)
-        wr_p1 <= wr;
+    always_comb wr_p1 = !cs_p1_n && !wr_p1_n;
 
     always_ff @(posedge clk_host) begin
         host_reg_wr.valid <= 0;
 
-        if (wr && !wr_p1)
-            if (!address[0]) begin // address write mode
-                host_reg_wr.bank_num <= address[1];
-                host_reg_wr.address <= din;
+        if (wr_p1)
+            if (!address_p1[0]) begin // address write mode
+                host_reg_wr.bank_num <= address_p1[1];
+                host_reg_wr.address <= din_p1;
             end
             else begin             // data write mode
                 host_reg_wr.valid <= 1;
-                host_reg_wr.data <= din;
+                host_reg_wr.data <= din_p1;
             end
 
-        if (!ic_n)
+        if (host_reg_wr.valid && host_reg_wr.bank_num == 0 && host_reg_wr.address == 'h2)
+            timer1 <= host_reg_wr.data;
+
+        if (!ic_n) begin
             host_reg_wr <= 0;
+            timer1 <= 0;
+        end
     end
 
-    always_comb rd = !cs_n && !rd_n;
+    always_comb rd_p1 = !cs_p1_n && !rd_p1_n;
 
     always_ff @(posedge clk_host) begin
-        rd_p1 <= rd;
+        rd_p2 <= rd_p1;
 
-        if (host_reg_wr.valid && host_reg_wr.bank_num == 0 && host_reg_wr.address == 'h4 && host_reg_wr.data[0]) begin
+        if (host_reg_wr.valid && host_reg_wr.bank_num == 0 && host_reg_wr.address == 'h4 && host_reg_wr.data[0] && timer1 == 'hff) begin
             start_counter <= 1;
             host_rd_counter <= 0;
             host_force_timer_overflow <= 0;
         end
 
-        if (start_counter && rd && !rd_p1)
+        if (start_counter && rd_p1 && !rd_p2)
             host_rd_counter <= host_rd_counter + 1;
 
         if (host_rd_counter == NUM_READS_TO_TRIGGER_OVERFLOW)

--- a/fpga/modules/top_level/pkg/opl3_pkg.sv
+++ b/fpga/modules/top_level/pkg/opl3_pkg.sv
@@ -51,7 +51,7 @@ package opl3_pkg;
      */
     localparam CLK_FREQ = 12.727e6;
     localparam DAC_OUTPUT_WIDTH = 24;
-    localparam INSTANTIATE_TIMERS = 1; // set to 1 to use timers, 0 to save area
+    localparam INSTANTIATE_TIMERS = 0; // set to 1 to use timers, 0 to save area
     localparam NUM_LEDS = 4; // connected to kon bank 0 starting at 0
     localparam INSTANTIATE_SAMPLE_SYNC_TO_DAC_CLK = 0;
 


### PR DESCRIPTION
Decompiled Doom OPL3 detection routine for DMXOPTION=-opl3-phase provided by Never_Again at https://www.vogons.org/viewtopic.php?f=7&t=100285. This env var now gets picked up by Doom and we finally have stereo!

The timing improvements came with some nice area reductions on Cyclone V.

Made normal adlib detection routine slightly more robust as well.