### PR TITLE
Reset is_new and connection regs, remove unused signal

### DIFF
--- a/fpga/modules/channels/src/channels.sv
+++ b/fpga/modules/channels/src/channels.sv
@@ -84,6 +84,12 @@ module channels
 
             if (opl3_reg_wr.bank_num == 0 && opl3_reg_wr.address == 'hBD)
                 ryt <= opl3_reg_wr.data[5];
+
+            if (reset) begin
+                // these should be reset as next game after reset may be OPL2 and not clear bank 1
+                connection_sel <= 0;
+                is_new <= 0;
+            end
         end
 
     mem_multi_bank #(

--- a/fpga/modules/operator/src/env_rate_counter.sv
+++ b/fpga/modules/operator/src/env_rate_counter.sv
@@ -73,7 +73,6 @@ module env_rate_counter
     logic [PIPELINE_DELAY:1] sample_clk_en_p;
     logic [PIPELINE_DELAY:1] [BANK_NUM_WIDTH-1:0] bank_num_p;
     logic [PIPELINE_DELAY:1] [OP_NUM_WIDTH-1:0] op_num_p;
-    logic key_on_pulse_p1 = 0;
 
     pipeline_sr #(
         .ENDING_CYCLE(PIPELINE_DELAY)


### PR DESCRIPTION
Games will typically clear both banks on start and exit. However, if a reset occurs during a game that is using OPL3 features and sets `new` and `connection` regs, the next game may be OPL2-only and not clear the second bank as it doesn't exist on the OPL2.

Not resetting the other regs in the second bank is fine as the envelope for all operators gets reset to the RELEASE state.